### PR TITLE
fixed typo in api/products route

### DIFF
--- a/server/api/products.js
+++ b/server/api/products.js
@@ -2,7 +2,7 @@ const router = require('express').Router()
 const {Products} = require('../db/models')
 module.exports = router
 
-router.get('/products', async (req, res, next) => {
+router.get('/', async (req, res, next) => {
   try {
     const products = await Products.findAll()
     res.json(products)

--- a/server/auth/index.js
+++ b/server/auth/index.js
@@ -1,5 +1,5 @@
 const router = require('express').Router()
-const User = require('../db/models/user')
+const User = require('../db/models/users')
 module.exports = router
 
 router.post('/login', async (req, res, next) => {


### PR DESCRIPTION
Changed '/products' to '/' since the api route was already mounted on /api/products. 
